### PR TITLE
Clicking on player avatar toggles InfoWindow state

### DIFF
--- a/PlayerMarkers/playermarkers/playermarkers.js
+++ b/PlayerMarkers/playermarkers/playermarkers.js
@@ -66,7 +66,11 @@ function updatePlayerMarkers() {
 							break;
 						}
 					}
-					infoWindowsArray[i].open(overviewer.map, playerMarkers[i]);
+					if(infoWindowsArray[i].getMap()){
+						infoWindowsArray[i].close()
+					} else {
+						infoWindowsArray[i].open(overviewer.map, playerMarkers[i]);
+					}
 				});
 				infoWindowsArray.push(infowindow);
 				foundPlayerMarkers.push(true);


### PR DESCRIPTION
This change makes it so that when a player avatar is clicked and the InfoWindow is already displayed, it is closed. Instead of only opening the infowindow, the avatar toggles it.

I think this flows more cleanly if you're going through and clicking on different players. If you're wanting to quickly open and close windows, it saves having to navigate to the fade-in 'x' button in the corner of the Info Window.

Thoughts?
