### PR TITLE
Only show online player markers, discard others (like offline players)

### DIFF
--- a/PlayerMarkers/playermarkers/playermarkers.js
+++ b/PlayerMarkers/playermarkers/playermarkers.js
@@ -111,6 +111,7 @@ function loadPlayers() {
                 if (overviewerConfig.map.debug)
                     //console.log('Updating ' +data[i].msg + ' from  ' + curTileSet.get("world").get("name"));
                 if (data[i].world != curTileSet.get("world").get("name")) continue;
+                if (data[i].id != 4) continue;
 
                 var item            =    data[i];
                 var name            =    item.msg;


### PR DESCRIPTION
This will help to prevent showing any markers that are not specifically "Online Player" markers (id: 4) from plugins where you can't easily remove them.
